### PR TITLE
Strict unmarshal

### DIFF
--- a/lib/mbr.ml
+++ b/lib/mbr.ml
@@ -212,7 +212,7 @@ let unmarshal (buf : Cstruct.t) : (t, string) result =
   >>= fun () ->
   let copy_protected = get_mbr_copy_protected buf in
   (match copy_protected with
-  | 0 -> Ok (copy_protected = 0x5a5a)
+  | 0 | 0x5a5a -> Ok (copy_protected = 0x5a5a)
   | _ ->
       Error (Printf.sprintf "Invalid copy protection value %d" copy_protected))
   >>= fun () ->


### PR DESCRIPTION
Check that the expected constant value `0x0000` is `0x0000` and the copy protection part of the disk signature is either `0x0000` or `0x5a5a` as is expected in a "modern standard MBR" (cf. https://en.wikipedia.org/wiki/Master_boot_record#Sector_layout)